### PR TITLE
Fix broken tap metrics in web interface

### DIFF
--- a/web-interface/src/components/system/taps/details/metrics/TapMetricsDetailsPage.jsx
+++ b/web-interface/src/components/system/taps/details/metrics/TapMetricsDetailsPage.jsx
@@ -35,7 +35,7 @@ function TapMetricsDetailsPage () {
                         <ol className="breadcrumb">
                             <li className="breadcrumb-item"><a href={ApiRoutes.SYSTEM.TAPS.INDEX}>Taps</a></li>
                             <li className="breadcrumb-item" aria-current="page">
-                                <a href={ApiRoutes.SYSTEM.TAPS.DETAILS(tap.name)}>{tap.name}</a>
+                                <a href={ApiRoutes.SYSTEM.TAPS.DETAILS(tap.uuid)}>{tap.name}</a>
                             </li>
                             <li className="breadcrumb-item" aria-current="page">Metrics</li>
                             <li className="breadcrumb-item active" aria-current="page">{metricName}</li>
@@ -43,7 +43,7 @@ function TapMetricsDetailsPage () {
                     </nav>
                 </div>
                 <div className="col-md-2">
-                    <a className="btn btn-primary float-end" href={ApiRoutes.SYSTEM.TAPS.DETAILS(tap.name)}>Back</a>
+                    <a className="btn btn-primary float-end" href={ApiRoutes.SYSTEM.TAPS.DETAILS(tap.uuid)}>Back</a>
                 </div>
             </div>
 
@@ -59,7 +59,7 @@ function TapMetricsDetailsPage () {
                         <div className="card-body">
                             <h3>Chart</h3>
 
-                            <TapMetricsChartProxy type={metricType} name={metricName} tapName={tapName} />
+                            <TapMetricsChartProxy type={metricType} name={metricName} tapUuid={tap.uuid} />
                         </div>
                     </div>
                 </div>

--- a/web-interface/src/components/system/taps/details/metrics/TapMetricsGauges.jsx
+++ b/web-interface/src/components/system/taps/details/metrics/TapMetricsGauges.jsx
@@ -25,7 +25,7 @@ function TapMetricsGauges (props) {
                         <td>{props.gauges[key].metric_name}</td>
                         <td><FormattedGauge name={props.gauges[key].metric_name} value={props.gauges[key].metric_value} /></td>
                         <td>
-                            <a href={ApiRoutes.SYSTEM.TAPS.METRICDETAILS(props.tap.name, 'gauge', props.gauges[key].metric_name)}>
+                            <a href={ApiRoutes.SYSTEM.TAPS.METRICDETAILS(props.tap.uuid, 'gauge', props.gauges[key].metric_name)}>
                                 Chart
                             </a>
                         </td>


### PR DESCRIPTION
The tap metrics page was still using the tap name as identifier, but we changed to the UUID is main identifier a long time ago.

Issue: #894 