### PR TITLE
Allow user to copy TOTP URL during MFA #919

### DIFF
--- a/web-interface/src/components/system/authentication/MFASetupStep1.jsx
+++ b/web-interface/src/components/system/authentication/MFASetupStep1.jsx
@@ -21,8 +21,34 @@ function MFASetupStep1(props) {
 
         <p className="mt-4">
           Scan the QR code with your preferred TOTP application like Google Authenticator, Authy
-          or the Yubikey Authenticator.
+          or the Yubikey Authenticator.{' '}
+          <a href="#" data-bs-toggle="modal" data-bs-target="#otp-url-modal">Show TOTP URL</a>
         </p>
+
+        <div className="modal fade"
+             id="otp-url-modal"
+             tabIndex="-1"
+             aria-labelledby="otp-url-modal-label"
+             aria-hidden="true">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-body">
+                <h2>TOTP URL</h2>
+
+                <p>
+                  Many TOTP applications allow you to enter the TOTP URL directly f you cannot scan the QR code:
+                </p>
+
+                <pre>
+                  {otpAuthUrl}
+                </pre>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+              </div>
+            </div>
+          </div>
+        </div>
 
         <button className="btn btn-primary mt-3" onClick={onAdvance}>Next Step</button>
       </React.Fragment>

--- a/web-interface/src/components/system/authentication/MFASetupStep1.jsx
+++ b/web-interface/src/components/system/authentication/MFASetupStep1.jsx
@@ -36,7 +36,7 @@ function MFASetupStep1(props) {
                 <h2>TOTP URL</h2>
 
                 <p>
-                  Many TOTP applications allow you to enter the TOTP URL directly f you cannot scan the QR code:
+                  Many TOTP applications allow you to enter the TOTP URL directly if you cannot scan the QR code:
                 </p>
 
                 <pre>


### PR DESCRIPTION
Some devices can't make use of the QR code (mobile devices for example). This change allows the user to manually copy the TOTP URL into their TOTP application.

![2023-09-05_19-43](https://github.com/nzymedefense/nzyme/assets/35022/22077fa6-a08d-49d7-8c04-7b3c8d737f09)

![2023-09-05_19-44](https://github.com/nzymedefense/nzyme/assets/35022/7eeefc29-c916-476a-a522-2edc0e58c7f0)