### PR TITLE
Improve detection alert and general subscription management

### DIFF
--- a/src/main/java/app/nzyme/core/detection/alerts/DetectionType.java
+++ b/src/main/java/app/nzyme/core/detection/alerts/DetectionType.java
@@ -10,7 +10,10 @@ public enum DetectionType {
     DOT11_MONITOR_SIGNAL_TRACK("WiFi Network Monitor: Multiple BSSID signal tracks detected", Subsystem.DOT11),
 
     // Other Dot11 alerts.
-    DOT11_BANDIT_CONTACT("WiFi Bandit detected", Subsystem.DOT11);
+    DOT11_BANDIT_CONTACT("WiFi Bandit detected", Subsystem.DOT11),
+
+    // Wildcard subscription.
+    WILDCARD("Subscribed to all detection alerts. (Wildcard)", Subsystem.GENERIC);
 
     private final String title;
     private final Subsystem subsystem;

--- a/src/main/java/app/nzyme/core/detection/alerts/Subsystem.java
+++ b/src/main/java/app/nzyme/core/detection/alerts/Subsystem.java
@@ -2,6 +2,6 @@ package app.nzyme.core.detection.alerts;
 
 public enum Subsystem {
 
-    DOT11, ETHERNET
+    DOT11, ETHERNET, GENERIC
 
 }

--- a/src/main/java/app/nzyme/core/events/actions/EventActionUtilities.java
+++ b/src/main/java/app/nzyme/core/events/actions/EventActionUtilities.java
@@ -1,12 +1,12 @@
 package app.nzyme.core.events.actions;
 
+import app.nzyme.core.detection.alerts.DetectionType;
 import app.nzyme.core.events.db.EventActionEntry;
-import app.nzyme.core.events.db.EventEntry;
 import app.nzyme.core.events.types.EventActionType;
-import app.nzyme.core.events.types.EventType;
 import app.nzyme.core.events.types.SystemEventType;
+import app.nzyme.core.rest.responses.events.DetectionEventTypeDetailsResponse;
 import app.nzyme.core.rest.responses.events.EventActionDetailsResponse;
-import app.nzyme.core.rest.responses.events.EventTypeDetailsResponse;
+import app.nzyme.core.rest.responses.events.SystemEventTypeDetailsResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,7 +20,9 @@ public class EventActionUtilities {
 
     private static final ObjectMapper om = new ObjectMapper();
 
-    public static EventActionDetailsResponse eventActionEntryToResponse(EventActionEntry ea, List<SystemEventType> subscribedToEvents) {
+    public static EventActionDetailsResponse eventActionEntryToResponse(EventActionEntry ea,
+                                                                        List<SystemEventType> subscribedSystemEvents,
+                                                                        List<DetectionType> subscribedDetectionEvents) {
         Map<String, Object> configuration;
 
 
@@ -30,9 +32,9 @@ public class EventActionUtilities {
             throw new RuntimeException("Could not read event action configuration.", e);
         }
 
-        List<EventTypeDetailsResponse> subscriptions = Lists.newArrayList();
-        for (SystemEventType subscription : subscribedToEvents) {
-            subscriptions.add(EventTypeDetailsResponse.create(
+        List<SystemEventTypeDetailsResponse> systemEventSubscriptions = Lists.newArrayList();
+        for (SystemEventType subscription : subscribedSystemEvents) {
+            systemEventSubscriptions.add(SystemEventTypeDetailsResponse.create(
                     subscription.name(),
                     subscription.getCategory().name(),
                     subscription.getCategory().getHumanReadableName(),
@@ -42,6 +44,14 @@ public class EventActionUtilities {
             ));
         }
 
+        List<DetectionEventTypeDetailsResponse> detectionEventSubscriptions = Lists.newArrayList();
+        for (DetectionType subscription : subscribedDetectionEvents) {
+            detectionEventSubscriptions.add(DetectionEventTypeDetailsResponse.create(
+                    subscription.name(),
+                    subscription.getTitle(),
+                    subscription.getSubsystem().name()
+            ));
+        }
 
         EventActionType actionType = EventActionType.valueOf(ea.actionType());
         return EventActionDetailsResponse.create(
@@ -52,7 +62,8 @@ public class EventActionUtilities {
                 ea.name(),
                 ea.description(),
                 configuration,
-                subscriptions,
+                systemEventSubscriptions,
+                detectionEventSubscriptions,
                 ea.createdAt(),
                 ea.updatedAt()
         );

--- a/src/main/java/app/nzyme/core/rest/resources/system/EventsResource.java
+++ b/src/main/java/app/nzyme/core/rest/resources/system/EventsResource.java
@@ -144,7 +144,7 @@ public class EventsResource extends UserAuthenticatedResource {
 
         EventEngineImpl eventEngine = ((EventEngineImpl) nzyme.getEventEngine());
 
-        List<EventTypeDetailsResponse> result = Lists.newArrayList();
+        List<SystemEventTypeDetailsResponse> result = Lists.newArrayList();
         for (SystemEventType entry : page) {
             List<SubscriptionDetailsResponse> subscriptions = Lists.newArrayList();
             for (SubscriptionEntry sub : eventEngine.findAllActionsOfSubscription(organizationId, entry.name())) {
@@ -153,7 +153,7 @@ public class EventsResource extends UserAuthenticatedResource {
                 );
             }
 
-            result.add(EventTypeDetailsResponse.create(
+            result.add(SystemEventTypeDetailsResponse.create(
                     entry.name(),
                     entry.getCategory().name(),
                     entry.getCategory().getHumanReadableName(),
@@ -200,7 +200,7 @@ public class EventsResource extends UserAuthenticatedResource {
             );
         }
 
-        return Response.ok(EventTypeDetailsResponse.create(
+        return Response.ok(SystemEventTypeDetailsResponse.create(
                 eventType.name(),
                 eventType.getCategory().name(),
                 eventType.getCategory().getHumanReadableName(),

--- a/src/main/java/app/nzyme/core/rest/resources/system/authentication/mgmt/OrganizationsResource.java
+++ b/src/main/java/app/nzyme/core/rest/resources/system/authentication/mgmt/OrganizationsResource.java
@@ -2,6 +2,7 @@ package app.nzyme.core.rest.resources.system.authentication.mgmt;
 
 import app.nzyme.core.NzymeNode;
 import app.nzyme.core.crypto.Crypto;
+import app.nzyme.core.detection.alerts.DetectionType;
 import app.nzyme.core.events.EventEngineImpl;
 import app.nzyme.core.events.actions.EventActionUtilities;
 import app.nzyme.core.events.db.EventActionEntry;
@@ -1267,8 +1268,16 @@ public class OrganizationsResource extends UserAuthenticatedResource {
         long total = eventEngine.countAllEventActionsOfOrganization(organizationId);
         List<EventActionDetailsResponse> events = Lists.newArrayList();
         for (EventActionEntry ea : eventEngine.findAllEventActionsOfOrganization(organizationId, limit, offset)) {
-            List<SystemEventType> subs = eventEngine.findAllEventTypesActionIsSubscribedTo(ea.uuid());
-            events.add(EventActionUtilities.eventActionEntryToResponse(ea, subs));
+            List<SystemEventType> subscribedSystemEvents = eventEngine
+                    .findAllSystemEventTypesActionIsSubscribedTo(ea.uuid());
+            List<DetectionType> subscribedDetectionEvents = eventEngine
+                    .findAllDetectionEventTypesActionIsSubscribedTo(ea.uuid());
+
+            events.add(EventActionUtilities.eventActionEntryToResponse(
+                    ea,
+                    subscribedSystemEvents,
+                    subscribedDetectionEvents
+            ));
         }
 
         return Response.ok(EventActionsListResponse.create(total, events)).build();
@@ -1297,9 +1306,16 @@ public class OrganizationsResource extends UserAuthenticatedResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        List<SystemEventType> subs = eventEngine.findAllEventTypesActionIsSubscribedTo(ea.get().uuid());
+        List<SystemEventType> subscribedSystemEvents = eventEngine
+                .findAllSystemEventTypesActionIsSubscribedTo(ea.get().uuid());
+        List<DetectionType> subscribedDetectionEvents = eventEngine
+                .findAllDetectionEventTypesActionIsSubscribedTo(ea.get().uuid());
 
-        return Response.ok(EventActionUtilities.eventActionEntryToResponse(ea.get(), subs)).build();
+        return Response.ok(EventActionUtilities.eventActionEntryToResponse(
+                ea.get(),
+                subscribedSystemEvents,
+                subscribedDetectionEvents
+        )).build();
     }
 
     @GET

--- a/src/main/java/app/nzyme/core/rest/responses/events/DetectionEventTypeDetailsResponse.java
+++ b/src/main/java/app/nzyme/core/rest/responses/events/DetectionEventTypeDetailsResponse.java
@@ -1,0 +1,40 @@
+package app.nzyme.core.rest.responses.events;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class DetectionEventTypeDetailsResponse {
+
+    @JsonProperty("event")
+    public abstract String event();
+
+    @JsonProperty("title")
+    public abstract String title();
+
+    @JsonProperty("subsystem")
+    public abstract String subsystem();
+
+    public static DetectionEventTypeDetailsResponse create(String event, String title, String subsystem) {
+        return builder()
+                .event(event)
+                .title(title)
+                .subsystem(subsystem)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_DetectionEventTypeDetailsResponse.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder event(String event);
+
+        public abstract Builder title(String title);
+
+        public abstract Builder subsystem(String subsystem);
+
+        public abstract DetectionEventTypeDetailsResponse build();
+    }
+}

--- a/src/main/java/app/nzyme/core/rest/responses/events/EventActionDetailsResponse.java
+++ b/src/main/java/app/nzyme/core/rest/responses/events/EventActionDetailsResponse.java
@@ -34,8 +34,11 @@ public abstract class EventActionDetailsResponse {
     @JsonProperty("configuration")
     public abstract Map<String, Object> configuration();
 
-    @JsonProperty("subscribed_to_events")
-    public abstract List<EventTypeDetailsResponse> subscribedToEvents();
+    @JsonProperty("subscribed_to_system_events")
+    public abstract List<SystemEventTypeDetailsResponse> subscribedToSystemEvents();
+
+    @JsonProperty("subscribed_to_detection_events")
+    public abstract List<DetectionEventTypeDetailsResponse> subscribedToDetectionEvents();
 
     @JsonProperty("created_at")
     public abstract DateTime createdAt();
@@ -43,7 +46,7 @@ public abstract class EventActionDetailsResponse {
     @JsonProperty("updated_at")
     public abstract DateTime updatedAt();
 
-    public static EventActionDetailsResponse create(UUID id, UUID organizationId, String actionType, String actionTypeHumanReadable, String name, String description, Map<String, Object> configuration, List<EventTypeDetailsResponse> subscribedToEvents, DateTime createdAt, DateTime updatedAt) {
+    public static EventActionDetailsResponse create(UUID id, UUID organizationId, String actionType, String actionTypeHumanReadable, String name, String description, Map<String, Object> configuration, List<SystemEventTypeDetailsResponse> subscribedToSystemEvents, List<DetectionEventTypeDetailsResponse> subscribedToDetectionEvents, DateTime createdAt, DateTime updatedAt) {
         return builder()
                 .id(id)
                 .organizationId(organizationId)
@@ -52,7 +55,8 @@ public abstract class EventActionDetailsResponse {
                 .name(name)
                 .description(description)
                 .configuration(configuration)
-                .subscribedToEvents(subscribedToEvents)
+                .subscribedToSystemEvents(subscribedToSystemEvents)
+                .subscribedToDetectionEvents(subscribedToDetectionEvents)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();
@@ -78,7 +82,9 @@ public abstract class EventActionDetailsResponse {
 
         public abstract Builder configuration(Map<String, Object> configuration);
 
-        public abstract Builder subscribedToEvents(List<EventTypeDetailsResponse> subscribedToEvents);
+        public abstract Builder subscribedToSystemEvents(List<SystemEventTypeDetailsResponse> subscribedToSystemEvents);
+
+        public abstract Builder subscribedToDetectionEvents(List<DetectionEventTypeDetailsResponse> subscribedToDetectionEvents);
 
         public abstract Builder createdAt(DateTime createdAt);
 

--- a/src/main/java/app/nzyme/core/rest/responses/events/EventTypesListResponse.java
+++ b/src/main/java/app/nzyme/core/rest/responses/events/EventTypesListResponse.java
@@ -12,9 +12,9 @@ public abstract class EventTypesListResponse {
     public abstract long count();
 
     @JsonProperty("types")
-    public abstract List<EventTypeDetailsResponse> types();
+    public abstract List<SystemEventTypeDetailsResponse> types();
 
-    public static EventTypesListResponse create(long count, List<EventTypeDetailsResponse> types) {
+    public static EventTypesListResponse create(long count, List<SystemEventTypeDetailsResponse> types) {
         return builder()
                 .count(count)
                 .types(types)
@@ -29,7 +29,7 @@ public abstract class EventTypesListResponse {
     public abstract static class Builder {
         public abstract Builder count(long count);
 
-        public abstract Builder types(List<EventTypeDetailsResponse> types);
+        public abstract Builder types(List<SystemEventTypeDetailsResponse> types);
 
         public abstract EventTypesListResponse build();
     }

--- a/src/main/java/app/nzyme/core/rest/responses/events/SystemEventTypeDetailsResponse.java
+++ b/src/main/java/app/nzyme/core/rest/responses/events/SystemEventTypeDetailsResponse.java
@@ -6,7 +6,7 @@ import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
-public abstract class EventTypeDetailsResponse {
+public abstract class SystemEventTypeDetailsResponse {
 
     @JsonProperty("id")
     public abstract String id();
@@ -26,7 +26,7 @@ public abstract class EventTypeDetailsResponse {
     @JsonProperty("subscriptions")
     public abstract List<SubscriptionDetailsResponse> subscriptions();
 
-    public static EventTypeDetailsResponse create(String id, String categoryId, String categoryName, String name, String description, List<SubscriptionDetailsResponse> subscriptions) {
+    public static SystemEventTypeDetailsResponse create(String id, String categoryId, String categoryName, String name, String description, List<SubscriptionDetailsResponse> subscriptions) {
         return builder()
                 .id(id)
                 .categoryId(categoryId)
@@ -38,7 +38,7 @@ public abstract class EventTypeDetailsResponse {
     }
 
     public static Builder builder() {
-        return new AutoValue_EventTypeDetailsResponse.Builder();
+        return new AutoValue_SystemEventTypeDetailsResponse.Builder();
     }
 
     @AutoValue.Builder
@@ -55,6 +55,6 @@ public abstract class EventTypeDetailsResponse {
 
         public abstract Builder subscriptions(List<SubscriptionDetailsResponse> subscriptions);
 
-        public abstract EventTypeDetailsResponse build();
+        public abstract SystemEventTypeDetailsResponse build();
     }
 }

--- a/web-interface/src/components/alerts/subscriptions/AlertSubscriptionsTable.jsx
+++ b/web-interface/src/components/alerts/subscriptions/AlertSubscriptionsTable.jsx
@@ -68,22 +68,22 @@ function AlertSubscriptionsTable() {
         <table className="table table-sm table-hover table-striped">
           <thead>
           <tr>
-            <th>Subsystem</th>
             <th>Detection Name</th>
+            <th>Subsystem</th>
             <th>Subscriptions</th>
-            <th>&nbsp;</th>
           </tr>
           </thead>
           <tbody>
           {types.types.map(function(type, i) {
             return (
                 <tr key={"at-" + i}>
-                  <td><Subsystem subsystem={type.subsystem} /></td>
-                  <td>{type.title}</td>
-                  <td>{type.subscriptions.length}</td>
                   <td>
-                    <a href={ApiRoutes.ALERTS.SUBSCRIPTIONS.DETAILS(organization.id, type.name.toLowerCase())}>Manage</a>
+                    <a href={ApiRoutes.ALERTS.SUBSCRIPTIONS.DETAILS(organization.id, type.name.toLowerCase())}>
+                      {type.title}
+                    </a>
                   </td>
+                  <td><Subsystem subsystem={type.subsystem} /></td>
+                  <td>{type.subscriptions.length}</td>
                 </tr>
             )
           })}

--- a/web-interface/src/components/layout/NavigationLink.jsx
+++ b/web-interface/src/components/layout/NavigationLink.jsx
@@ -12,15 +12,24 @@ function NavigationLink(props) {
     return null;
   }
 
-  let className = 'nav-link'
-  let liClassName = '';
-  if ((window.location.pathname === '/' && href === '/')
+  const inactiveClassName = "nav-link";
+  let className = inactiveClassName;
+  let liClassName = "";
+  if ((window.location.pathname === "/" && href === "/")
       || (href !== '/' && window.location.pathname.startsWith(href))) {
     className += ' nav-link-active'
     liClassName = 'nav-item-active'
   }
+
+  // Handle special cases.
+  if (title === "Organization" && window.location.pathname.includes("/events")) {
+    // Org events are nested under organization for super admin access. Don't mark both Events and Organization as active.
+    className = inactiveClassName;
+    liClassName = "";
+  }
+
   return (
-    <li className={'nav-item ' + liClassName}>
+    <li className={"nav-item " + liClassName}>
       <a href={href} className={className}>
         <span className="nav-icon">{icon}</span>
         {title}

--- a/web-interface/src/components/layout/Sidebar.jsx
+++ b/web-interface/src/components/layout/Sidebar.jsx
@@ -136,6 +136,11 @@ function Sidebar() {
             title="Events &amp; Actions"
             icon={<i className="sidebar-icon fa-solid fa-bolt" />} />
         <NavigationLink
+            show={user.is_orgadmin}
+            href={ApiRoutes.SYSTEM.AUTHENTICATION.MANAGEMENT.ORGANIZATIONS.EVENTS.INDEX(user.organization_id)}
+            title="Events &amp; Actions"
+            icon={<i className="sidebar-icon fa-solid fa-bolt" />} />
+        <NavigationLink
             href={ApiRoutes.SYSTEM.AUTHENTICATION.MANAGEMENT.INDEX}
             title={user.is_superadmin ? "Authentication" : "Organization" }
             icon={<i className="sidebar-icon fa-solid fa-users" />} />

--- a/web-interface/src/components/misc/Subsystem.jsx
+++ b/web-interface/src/components/misc/Subsystem.jsx
@@ -3,6 +3,8 @@ function Subsystem(props) {
   const subsystem = props.subsystem;
 
   switch (subsystem) {
+    case "GENERIC":
+      return "Generic / Other";
     case "DOT11":
       return "802.11 / WiFi";
     case "ETHERNET":

--- a/web-interface/src/components/misc/WithExactRole.jsx
+++ b/web-interface/src/components/misc/WithExactRole.jsx
@@ -1,0 +1,33 @@
+import {useContext} from "react";
+import {UserContext} from "../../App";
+
+function WithExactRole(props) {
+
+  const user = useContext(UserContext);
+
+  const role = props.role;
+
+  let show = false;
+  switch(role) {
+    case "SUPERADMIN":
+      show = user.is_superadmin;
+      break;
+    case "ORGADMIN":
+      show = user.is_orgadmin;
+      break;
+    case "TENANTUSER":
+      show = !user.is_superadmin && !user.is_orgadmin;
+      break;
+    default:
+      return null;
+  }
+
+  if (!show) {
+    return null;
+  }
+
+  return props.children;
+
+}
+
+export default WithExactRole;

--- a/web-interface/src/components/misc/WithPermission.jsx
+++ b/web-interface/src/components/misc/WithPermission.jsx
@@ -1,4 +1,4 @@
-import React, {useContext} from "react";
+import {useContext} from "react";
 import {UserContext} from "../../App";
 import {userHasPermission} from "../../util/Tools";
 

--- a/web-interface/src/components/system/authentication/management/organizations/OrganizationDetailsPage.jsx
+++ b/web-interface/src/components/system/authentication/management/organizations/OrganizationDetailsPage.jsx
@@ -9,6 +9,7 @@ import ApiRoutes from "../../../../../util/ApiRoutes";
 import OrganizationSessions from "../sessions/OrganizationSessions";
 import OrganizationAdminTable from "../users/orgadmins/OrganizationAdminTable";
 import {UserContext} from "../../../../../App";
+import WithExactRole from "../../../../misc/WithExactRole";
 
 const authenticationManagementService = new AuthenticationManagementService();
 
@@ -133,25 +134,27 @@ function OrganizationDetailsPage() {
               </div>
             </div>
 
-            <div className="row mt-3">
-              <div className="col-md-12">
-                <div className="card">
-                  <div className="card-body">
-                    <h3>Events &amp; Actions</h3>
+            <WithExactRole role="SUPERADMIN">
+              <div className="row mt-3">
+                <div className="col-md-12">
+                  <div className="card">
+                    <div className="card-body">
+                      <h3>Events &amp; Actions</h3>
 
-                    <p>
-                      Events, such as system notifications or detection alerts, within this organization, have the
-                      ability to trigger actions, which are managed on the events & action pages.
-                    </p>
+                      <p>
+                        Events, such as system notifications or detection alerts, within this organization, have the
+                        ability to trigger actions, which are managed on the events & action pages.
+                      </p>
 
-                    <a href={ApiRoutes.SYSTEM.AUTHENTICATION.MANAGEMENT.ORGANIZATIONS.EVENTS.INDEX(organization.id)}
-                       className="btn btn-secondary btn-sm">
-                      Manage Organization Events &amp; Actions
-                    </a>
+                      <a href={ApiRoutes.SYSTEM.AUTHENTICATION.MANAGEMENT.ORGANIZATIONS.EVENTS.INDEX(organization.id)}
+                         className="btn btn-secondary btn-sm">
+                        Manage Organization Events &amp; Actions
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </WithExactRole>
           </div>
 
           <div className="col-md-6">

--- a/web-interface/src/components/system/authentication/management/organizations/events/actions/OrganizationActionDetailsPage.jsx
+++ b/web-interface/src/components/system/authentication/management/organizations/events/actions/OrganizationActionDetailsPage.jsx
@@ -7,7 +7,9 @@ import EventActionsService from "../../../../../../../services/EventActionsServi
 import {notify} from "react-notify-toast";
 import ActionDetailsProxy from "../../../../../events/shared/details/ActionDetailsProxy";
 import ActionDetails from "../../../../../events/shared/ActionDetails";
-import SubscriptionsOfActionTable from "../../../../../events/shared/subscriptions/SubscriptionsOfActionTable";
+import SystemSubscriptionsOfActionTable from "../../../../../events/shared/subscriptions/SystemSubscriptionsOfActionTable";
+import DetectionSubscriptionsOfActionTable
+  from "../../../../../events/shared/subscriptions/DetectionSubscriptionsOfActionTable";
 
 const authenticationMgmtService = new AuthenticationManagementService();
 const eventActionsService = new EventActionsService();
@@ -140,8 +142,13 @@ function OrganizationActionDetailsPage() {
 
                     <p>This action is subscribed to the following events:</p>
 
-                    <SubscriptionsOfActionTable subscriptions={action.subscribed_to_events}
-                                                organizationId={organization.id} />
+                    <h4>System Events</h4>
+                    <SystemSubscriptionsOfActionTable subscriptions={action.subscribed_to_system_events}
+                                                      organizationId={organization.id} />
+
+                    <h4 className="mt-4">Detection Events</h4>
+                    <DetectionSubscriptionsOfActionTable subscriptions={action.subscribed_to_detection_events}
+                                                         organizationId={organization.id} />
                   </div>
                 </div>
               </div>
@@ -163,7 +170,7 @@ function OrganizationActionDetailsPage() {
                     <button type="button"
                             className="btn btn-danger"
                             onClick={onDelete}
-                            disabled={action.subscribed_to_events.length > 0}>
+                            disabled={action.subscribed_to_system_events.length > 0 || action.subscribed_to_detection_events.length > 0}>
                       Delete Action
                     </button>
                   </div>

--- a/web-interface/src/components/system/events/actions/ActionDetailsPage.jsx
+++ b/web-interface/src/components/system/events/actions/ActionDetailsPage.jsx
@@ -6,7 +6,8 @@ import ActionDetails from "../shared/ActionDetails";
 import ActionDetailsProxy from "../shared/details/ActionDetailsProxy";
 import EventActionsService from "../../../../services/EventActionsService";
 import ApiRoutes from "../../../../util/ApiRoutes";
-import SubscriptionsOfActionTable from "../shared/subscriptions/SubscriptionsOfActionTable";
+import SystemSubscriptionsOfActionTable from "../shared/subscriptions/SystemSubscriptionsOfActionTable";
+import DetectionSubscriptionsOfActionTable from "../shared/subscriptions/DetectionSubscriptionsOfActionTable";
 
 const eventActionsService = new EventActionsService();
 
@@ -119,7 +120,14 @@ function ActionDetailsPage() {
 
                     <p>This action is subscribed to the following events:</p>
 
-                    <SubscriptionsOfActionTable subscriptions={action.subscribed_to_events} />
+                    <h4>System Events</h4>
+                    <SystemSubscriptionsOfActionTable subscriptions={action.subscribed_to_system_events} />
+
+                    <h4 className="mt-4">Detection Events</h4>
+                    <div className="alert alert-info mb-0">
+                      Superadministrator actions cannot be subscribed to detection events. Please use organization
+                      actions.
+                    </div>
                   </div>
                 </div>
               </div>
@@ -141,7 +149,7 @@ function ActionDetailsPage() {
                     <button type="button"
                             className="btn btn-danger"
                             onClick={onDelete}
-                            disabled={action.subscribed_to_events.length > 0}>
+                            disabled={action.subscribed_to_system_events.length > 0 || action.subscribed_to_detection_events.length > 0}>
                       Delete Action
                     </button>
                   </div>

--- a/web-interface/src/components/system/events/shared/subscriptions/DetectionSubscriptionsOfActionTable.jsx
+++ b/web-interface/src/components/system/events/shared/subscriptions/DetectionSubscriptionsOfActionTable.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Subsystem from "../../../../misc/Subsystem";
+import ApiRoutes from "../../../../../util/ApiRoutes";
+
+function DetectionSubscriptionsOfActionTable(props) {
+
+  const subscriptions = props.subscriptions;
+  const organizationId = props.organizationId;
+
+  if (!subscriptions || subscriptions.length === 0) {
+    return <div className="alert alert-info mt-0 mb-0">Action is not subscribed to any detection events.</div>
+  }
+
+  return (
+      <table className="table table-sm table-hover table-striped">
+        <thead>
+        <tr>
+          <th>Detection Event Name</th>
+          <th>Title</th>
+          <th>Subsystem</th>
+        </tr>
+        </thead>
+        <tbody>
+        {subscriptions.map((type, i) => {
+          return (
+              <tr key={"eventtype-" + i}>
+                <td>
+                  { type.event === "WILDCARD" ? type.event :
+                    <a href={ApiRoutes.ALERTS.SUBSCRIPTIONS.DETAILS(organizationId, type.event)}>{type.event}</a>
+                  }
+                </td>
+                <td>{type.title}</td>
+                <td><Subsystem subsystem={type.subsystem} /></td>
+              </tr>
+          )
+        })}
+        </tbody>
+      </table>
+  )
+
+}
+
+export default DetectionSubscriptionsOfActionTable;

--- a/web-interface/src/components/system/events/shared/subscriptions/SystemSubscriptionsOfActionTable.jsx
+++ b/web-interface/src/components/system/events/shared/subscriptions/SystemSubscriptionsOfActionTable.jsx
@@ -1,20 +1,20 @@
 import React from "react";
 import ApiRoutes from "../../../../../util/ApiRoutes";
 
-function SubscriptionsOfActionTable(props) {
+function SystemSubscriptionsOfActionTable(props) {
 
   const subscriptions = props.subscriptions;
   const organizationId = props.organizationId;
 
   if (!subscriptions || subscriptions.length === 0) {
-    return <div className="alert alert-info mt-0 mb-0">Action is not subscribed to any events.</div>
+    return <div className="alert alert-info mt-0 mb-0">Action is not subscribed to any system events.</div>
   }
 
   return (
       <table className="table table-sm table-hover table-striped">
         <thead>
         <tr>
-          <th>Event Name</th>
+          <th>System Event Name</th>
           <th>Category</th>
         </tr>
         </thead>
@@ -39,4 +39,4 @@ function SubscriptionsOfActionTable(props) {
 
 }
 
-export default SubscriptionsOfActionTable;
+export default SystemSubscriptionsOfActionTable;


### PR DESCRIPTION
A few bugfixes and improvements for detection alert and general subscription management:

* Actions now also list subscribed detection alerts
* The "Manage" link of detection alert subscriptions moved to the type title instead of it's own "Manage" column (which is standard across the UI)
* Organization administrators had a hard time finding their *Events & Actions* management page because it was nested under their organization management page. This makes sense for super admins, but not for org admins. This PR moves the management link out of the org management page and to it's own sidebar link if the logged in user is an org admin.