### PR TITLE
Custom track detector configuration

### DIFF
--- a/src/main/java/app/nzyme/core/database/DatabaseImpl.java
+++ b/src/main/java/app/nzyme/core/database/DatabaseImpl.java
@@ -13,6 +13,7 @@ import app.nzyme.core.distributed.messaging.postgres.PostgresMessageEntryMapper;
 import app.nzyme.core.distributed.tasksqueue.postgres.PostgresTasksQueueEntryMapper;
 import app.nzyme.core.dot11.db.*;
 import app.nzyme.core.dot11.db.monitoring.*;
+import app.nzyme.core.dot11.tracks.db.TrackDetectorConfigMapper;
 import app.nzyme.core.events.db.EventActionEntryMapper;
 import app.nzyme.core.events.db.EventEntryMapper;
 import app.nzyme.core.events.db.SubscriptionEntryMapper;
@@ -118,7 +119,8 @@ public class DatabaseImpl implements Database {
                 .registerRowMapper(new BSSIDWithTapMapper())
                 .registerRowMapper(new DetectionAlertEntryMapper())
                 .registerRowMapper(new DetectionAlertAttributeEntryMapper())
-                .registerRowMapper(new DetectionAlertTimelineEntryMapper());
+                .registerRowMapper(new DetectionAlertTimelineEntryMapper())
+                .registerRowMapper(new TrackDetectorConfigMapper());
 
         if (configuration.slowQueryLogThreshold().isPresent()) {
             LOG.info("Slow query log enabled with threshold <{}ms>.", configuration.slowQueryLogThreshold().get());

--- a/src/main/java/app/nzyme/core/dot11/Dot11.java
+++ b/src/main/java/app/nzyme/core/dot11/Dot11.java
@@ -327,20 +327,16 @@ public class Dot11 {
                                                                       String ssid,
                                                                       int frequency,
                                                                       int minutes,
-                                                                      List<UUID> taps) {
-        if (taps.isEmpty()) {
-            return Collections.emptyList();
-        }
-
+                                                                      UUID tapId) {
         return nzyme.getDatabase().withHandle(handle ->
                 handle.createQuery("SELECT DATE_TRUNC('minute', s.created_at) AS bucket, signal_strength, " +
                                 "SUM(frame_count) AS frame_count FROM dot11_ssids AS s " +
                                 "LEFT JOIN dot11_channel_histograms h on s.id = h.ssid_id " +
-                                "WHERE created_at > :cutoff AND s.tap_uuid IN (<taps>) AND bssid = :bssid " +
+                                "WHERE created_at > :cutoff AND s.tap_uuid = :tap_id AND bssid = :bssid " +
                                 "AND ssid = :ssid AND h.frequency = :frequency " +
                                 "GROUP BY bucket, signal_strength ORDER BY bucket DESC")
                         .bind("cutoff", DateTime.now().minusMinutes(minutes))
-                        .bindList("taps", taps)
+                        .bind("tap_id", tapId)
                         .bind("bssid", bssid)
                         .bind("ssid", ssid)
                         .bind("frequency", frequency)

--- a/src/main/java/app/nzyme/core/dot11/Dot11.java
+++ b/src/main/java/app/nzyme/core/dot11/Dot11.java
@@ -4,6 +4,8 @@ import app.nzyme.core.NzymeNode;
 import app.nzyme.core.database.OrderDirection;
 import app.nzyme.core.dot11.db.*;
 import app.nzyme.core.dot11.db.monitoring.*;
+import app.nzyme.core.dot11.tracks.TrackDetector;
+import app.nzyme.core.dot11.tracks.db.TrackDetectorConfig;
 import app.nzyme.core.rest.resources.taps.reports.tables.dot11.Dot11SecurityInformationReport;
 import app.nzyme.core.rest.responses.dot11.clients.ConnectedBSSID;
 import app.nzyme.core.util.Tools;
@@ -344,6 +346,24 @@ public class Dot11 {
                         .bind("frequency", frequency)
                         .mapTo(ChannelHistogramEntry.class)
                         .list()
+        );
+    }
+
+    public Optional<TrackDetectorConfig> findCustomTrackDetectorConfiguration(UUID organizationId,
+                                                                              String bssid,
+                                                                              String ssid,
+                                                                              int channel) {
+        return nzyme.getDatabase().withHandle(handle ->
+                handle.createQuery("SELECT frame_threshold, gap_threshold, signal_centerline_jitter " +
+                                "FROM dot11_track_detector_configuration " +
+                                "WHERE organization_id = :organization_id AND bssid = :bssid AND ssid = :ssid " +
+                                "AND channel = :channel")
+                        .bind("organization_id", organizationId)
+                        .bind("bssid", bssid)
+                        .bind("ssid", ssid)
+                        .bind("channel", channel)
+                        .mapTo(TrackDetectorConfig.class)
+                        .findOne()
         );
     }
 

--- a/src/main/java/app/nzyme/core/dot11/tracks/TrackDetector.java
+++ b/src/main/java/app/nzyme/core/dot11/tracks/TrackDetector.java
@@ -1,6 +1,7 @@
 package app.nzyme.core.dot11.tracks;
 
 import app.nzyme.core.dot11.db.ChannelHistogramEntry;
+import app.nzyme.core.dot11.tracks.db.TrackDetectorConfig;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -50,7 +51,7 @@ public class TrackDetector {
                         gapLength++;
 
                         if (gapLength >= config.gapThreshold() || x == 0) {
-                            PartialTrack partialTrack = PartialTrack.create( y, trackStart, x-config.gapThreshold()+2);
+                            PartialTrack partialTrack = PartialTrack.create(y, trackStart, x-config.gapThreshold()+2);
 
                             if (!partialTracks.containsKey(partialTrack.averageSignal())) {
                                 partialTracks.put(partialTrack.averageSignal(), Lists.newArrayList());
@@ -189,37 +190,5 @@ public class TrackDetector {
             public abstract TrackDetectorHeatmapData build();
         }
     }
-
-    @AutoValue
-    public static abstract class TrackDetectorConfig {
-
-        public abstract int frameThreshold();
-        public abstract int gapThreshold();
-        public abstract int signalCenterlineJitter();
-
-        public static TrackDetectorConfig create(int frameThreshold, int gapThreshold, int signalCenterlineJitter) {
-            return builder()
-                    .frameThreshold(frameThreshold)
-                    .gapThreshold(gapThreshold)
-                    .signalCenterlineJitter(signalCenterlineJitter)
-                    .build();
-        }
-
-        public static Builder builder() {
-            return new AutoValue_TrackDetector_TrackDetectorConfig.Builder();
-        }
-
-        @AutoValue.Builder
-        public abstract static class Builder {
-            public abstract Builder frameThreshold(int frameThreshold);
-
-            public abstract Builder gapThreshold(int gapThreshold);
-
-            public abstract Builder signalCenterlineJitter(int signalCenterlineJitter);
-
-            public abstract TrackDetectorConfig build();
-        }
-    }
-
 
 }

--- a/src/main/java/app/nzyme/core/dot11/tracks/db/TrackDetectorConfig.java
+++ b/src/main/java/app/nzyme/core/dot11/tracks/db/TrackDetectorConfig.java
@@ -1,0 +1,34 @@
+package app.nzyme.core.dot11.tracks.db;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class TrackDetectorConfig {
+
+    public abstract int frameThreshold();
+    public abstract int gapThreshold();
+    public abstract int signalCenterlineJitter();
+
+    public static TrackDetectorConfig create(int frameThreshold, int gapThreshold, int signalCenterlineJitter) {
+        return builder()
+                .frameThreshold(frameThreshold)
+                .gapThreshold(gapThreshold)
+                .signalCenterlineJitter(signalCenterlineJitter)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_TrackDetectorConfig.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder frameThreshold(int frameThreshold);
+
+        public abstract Builder gapThreshold(int gapThreshold);
+
+        public abstract Builder signalCenterlineJitter(int signalCenterlineJitter);
+
+        public abstract TrackDetectorConfig build();
+    }
+}

--- a/src/main/java/app/nzyme/core/dot11/tracks/db/TrackDetectorConfigMapper.java
+++ b/src/main/java/app/nzyme/core/dot11/tracks/db/TrackDetectorConfigMapper.java
@@ -1,0 +1,20 @@
+package app.nzyme.core.dot11.tracks.db;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class TrackDetectorConfigMapper implements RowMapper<TrackDetectorConfig> {
+
+    @Override
+    public TrackDetectorConfig map(ResultSet rs, StatementContext ctx) throws SQLException {
+        return TrackDetectorConfig.create(
+                rs.getInt("frame_threshold"),
+                rs.getInt("gap_threshold"),
+                rs.getInt("signal_centerline_jitter")
+        );
+    }
+
+}

--- a/src/main/java/app/nzyme/core/rest/requests/UpdateTrackDetectorConfigurationRequest.java
+++ b/src/main/java/app/nzyme/core/rest/requests/UpdateTrackDetectorConfigurationRequest.java
@@ -1,0 +1,48 @@
+package app.nzyme.core.rest.requests;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+@AutoValue
+public abstract class UpdateTrackDetectorConfigurationRequest {
+
+    public abstract UUID tapId();
+    public abstract long frameThreshold();
+    public abstract long gapThreshold();
+    public abstract long signalCenterlineJitter();
+
+    @JsonCreator
+    public static UpdateTrackDetectorConfigurationRequest create(@JsonProperty("tap_id") @NotNull UUID tapId,
+                                                                 @JsonProperty("frame_threshold") long frameThreshold,
+                                                                 @JsonProperty("gap_threshold")  long gapThreshold,
+                                                                 @JsonProperty("signal_centerline_jitter") long signalCenterlineJitter) {
+        return builder()
+                .tapId(tapId)
+                .frameThreshold(frameThreshold)
+                .gapThreshold(gapThreshold)
+                .signalCenterlineJitter(signalCenterlineJitter)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_UpdateTrackDetectorConfigurationRequest.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder tapId(UUID tapId);
+
+        public abstract Builder frameThreshold(long frameThreshold);
+
+        public abstract Builder gapThreshold(long gapThreshold);
+
+        public abstract Builder signalCenterlineJitter(long signalCenterlineJitter);
+
+        public abstract UpdateTrackDetectorConfigurationRequest build();
+    }
+
+}

--- a/src/main/java/app/nzyme/core/rest/resources/dot11/Dot11NetworksResource.java
+++ b/src/main/java/app/nzyme/core/rest/resources/dot11/Dot11NetworksResource.java
@@ -323,7 +323,7 @@ public class Dot11NetworksResource extends TapDataHandlingResource {
                 .orElse(TrackDetector.DEFAULT_CONFIG);
 
         List<ChannelHistogramEntry> signals = nzyme.getDot11().getSSIDSignalStrengthWaterfall(
-                bssid, ssid, frequency, minutes, tapUuids);
+                bssid, ssid, frequency, minutes, tap.uuid());
 
         TrackDetector.TrackDetectorHeatmapData heatmap = TrackDetector.toChartAxisMaps(signals);
 

--- a/src/main/java/app/nzyme/core/rest/responses/dot11/SignalWaterfallConfigurationResponse.java
+++ b/src/main/java/app/nzyme/core/rest/responses/dot11/SignalWaterfallConfigurationResponse.java
@@ -1,0 +1,58 @@
+package app.nzyme.core.rest.responses.dot11;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class SignalWaterfallConfigurationResponse {
+
+    @JsonProperty("frame_threshold")
+    public abstract long frameThreshold();
+
+    @JsonProperty("frame_threshold_default")
+    public abstract long frameThresholdDefault();
+
+    @JsonProperty("gap_threshold")
+    public abstract long gapThreshold();
+
+    @JsonProperty("gap_threshold_default")
+    public abstract long gapThresholdDefault();
+
+    @JsonProperty("signal_centerline_jitter")
+    public abstract long signalCenterlineJitter();
+
+    @JsonProperty("signal_centerline_jitter_default")
+    public abstract long signalCenterlineJitterDefault();
+
+    public static SignalWaterfallConfigurationResponse create(long frameThreshold, long frameThresholdDefault, long gapThreshold, long gapThresholdDefault, long signalCenterlineJitter, long signalCenterlineJitterDefault) {
+        return builder()
+                .frameThreshold(frameThreshold)
+                .frameThresholdDefault(frameThresholdDefault)
+                .gapThreshold(gapThreshold)
+                .gapThresholdDefault(gapThresholdDefault)
+                .signalCenterlineJitter(signalCenterlineJitter)
+                .signalCenterlineJitterDefault(signalCenterlineJitterDefault)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_SignalWaterfallConfigurationResponse.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder frameThreshold(long frameThreshold);
+
+        public abstract Builder frameThresholdDefault(long frameThresholdDefault);
+
+        public abstract Builder gapThreshold(long gapThreshold);
+
+        public abstract Builder gapThresholdDefault(long gapThresholdDefault);
+
+        public abstract Builder signalCenterlineJitter(long signalCenterlineJitter);
+
+        public abstract Builder signalCenterlineJitterDefault(long signalCenterlineJitterDefault);
+
+        public abstract SignalWaterfallConfigurationResponse build();
+    }
+}

--- a/src/main/java/app/nzyme/core/rest/responses/dot11/SignalWaterfallResponse.java
+++ b/src/main/java/app/nzyme/core/rest/responses/dot11/SignalWaterfallResponse.java
@@ -21,12 +21,16 @@ public abstract class SignalWaterfallResponse {
     @JsonProperty("tracks")
     public abstract List<SignalWaterfallTrackResponse> tracks();
 
-    public static SignalWaterfallResponse create(List<List<Long>> z, List<Integer> x, List<DateTime> y, List<SignalWaterfallTrackResponse> tracks) {
+    @JsonProperty("detector_configuration")
+    public abstract SignalWaterfallConfigurationResponse detectorConfiguration();
+
+    public static SignalWaterfallResponse create(List<List<Long>> z, List<Integer> x, List<DateTime> y, List<SignalWaterfallTrackResponse> tracks, SignalWaterfallConfigurationResponse detectorConfiguration) {
         return builder()
                 .z(z)
                 .x(x)
                 .y(y)
                 .tracks(tracks)
+                .detectorConfiguration(detectorConfiguration)
                 .build();
     }
 
@@ -43,6 +47,8 @@ public abstract class SignalWaterfallResponse {
         public abstract Builder y(List<DateTime> y);
 
         public abstract Builder tracks(List<SignalWaterfallTrackResponse> tracks);
+
+        public abstract Builder detectorConfiguration(SignalWaterfallConfigurationResponse detectorConfiguration);
 
         public abstract SignalWaterfallResponse build();
     }

--- a/src/main/resources/db/migrations.xml
+++ b/src/main/resources/db/migrations.xml
@@ -3689,5 +3689,53 @@
             </column>
         </addColumn>
     </changeSet>
-    
+
+    <changeSet id="add_custom_track_detector_config" author="lennartkoopmann">
+        <createTable tableName="dot11_track_detector_configuration">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+
+            <column name="uuid" type="uuid">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="organization_id" type="uuid">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="bssid" type="varchar(17)">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="ssid" type="varchar(32)">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="channel" type="integer">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="frame_threshold" type="integer">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="gap_threshold" type="integer">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="signal_centerline_jitter" type="integer">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="updated_at" type="timestamp with time zone">
+                <constraints nullable="false" />
+            </column>
+
+            <column name="created_at" type="timestamp with time zone">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/migrations.xml
+++ b/src/main/resources/db/migrations.xml
@@ -3738,4 +3738,12 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="add_tap_uuid_to_track_detector_configs" author="lennartkoopmann">
+        <addColumn tableName="dot11_track_detector_configuration">
+            <column name="tap_id" type="uuid">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/web-interface/src/components/alerts/alertdetails/dot11/MonitorSignalTrackAlertDetails.jsx
+++ b/web-interface/src/components/alerts/alertdetails/dot11/MonitorSignalTrackAlertDetails.jsx
@@ -22,6 +22,8 @@ function MonitorSignalTrackAlertDetails(props) {
                     {dot11FrequencyToChannel(alert.attributes.channel)}{' '}
                     ({numeral(alert.attributes.channel).format("0,0")} MHz)
                   </dd>
+                  <dt>Recorded by Tap</dt>
+                  <dd>{alert.attributes.tap_name}</dd>
 
                   <p className="mb-0 mt-2">
                     One of the monitored access points is transmitting on multiple signal tracks. This might suggest

--- a/web-interface/src/components/dot11/bssids/ssids/SSIDDetailsPage.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/SSIDDetailsPage.jsx
@@ -17,7 +17,6 @@ import {dot11FrequencyToChannel} from "../../../../util/Tools";
 import ChannelSelector from "../../util/ChannelSelector";
 import SSIDMonitoredInformation from "./SSIDMonitoredInformation";
 import HelpBubble from "../../../misc/HelpBubble";
-import TrackDetectorConfigModal from "./TrackDetectorConfigModal";
 
 const dot11Service = new Dot11Service();
 const DEFAULT_MINUTES = 15;
@@ -201,14 +200,6 @@ function SSIDDetailsPage() {
                                                 ssid={ssid.ssid}
                                                 frequency={selectedFrequency}
                                                 minutes={24*60} />
-
-                      <TrackDetectorConfigModal />
-
-                      <button className="btn btn-sm btn-outline-secondary"
-                              data-bs-toggle="modal"
-                              data-bs-target="#track-detector-config">
-                        Configure Track Detector
-                      </button>
                     </div>
                   </div>
                 </div>

--- a/web-interface/src/components/dot11/bssids/ssids/SSIDDetailsPage.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/SSIDDetailsPage.jsx
@@ -17,6 +17,7 @@ import {dot11FrequencyToChannel} from "../../../../util/Tools";
 import ChannelSelector from "../../util/ChannelSelector";
 import SSIDMonitoredInformation from "./SSIDMonitoredInformation";
 import HelpBubble from "../../../misc/HelpBubble";
+import TrackDetectorConfigModal from "./TrackDetectorConfigModal";
 
 const dot11Service = new Dot11Service();
 const DEFAULT_MINUTES = 15;
@@ -184,7 +185,7 @@ function SSIDDetailsPage() {
                   <div className="card">
                     <div className="card-body">
                       <h3 style={{display: "inline-block"}}>
-                        Signal Strength Waterfall for Channel {dot11FrequencyToChannel(selectedFrequency)}{' '}
+                        Signal Waterfall for Channel {dot11FrequencyToChannel(selectedFrequency)}{' '}
                         ({numeral(selectedFrequency).format("0,0")} MHz) <small>Last 24 hours maximum</small>
                       </h3>
 
@@ -200,6 +201,14 @@ function SSIDDetailsPage() {
                                                 ssid={ssid.ssid}
                                                 frequency={selectedFrequency}
                                                 minutes={24*60} />
+
+                      <TrackDetectorConfigModal />
+
+                      <button className="btn btn-sm btn-outline-secondary"
+                              data-bs-toggle="modal"
+                              data-bs-target="#track-detector-config">
+                        Configure Track Detector
+                      </button>
                     </div>
                   </div>
                 </div>

--- a/web-interface/src/components/dot11/bssids/ssids/SSIDSignalWaterfallChart.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/SSIDSignalWaterfallChart.jsx
@@ -22,6 +22,7 @@ function SSIDSignalWaterfallChart(props) {
   const selectedTaps = tapContext.taps;
 
   const [waterfall, setWaterfall] = useState(null);
+  const [revision, setRevision] = useState(0);
 
   const formatData = function(data) {
     const yDates = [];
@@ -131,7 +132,7 @@ function SSIDSignalWaterfallChart(props) {
       setWaterfall(null);
       dot11Service.getSSIDOfBSSIDSignalWaterfall(bssid, ssid, frequency, minutes, selectedTaps, setWaterfall);
     }
-  }, [bssid, ssid, frequency, minutes, selectedTaps])
+  }, [bssid, ssid, frequency, minutes, selectedTaps, revision])
 
   if (!singleTapSelected(selectedTaps)) {
     return (
@@ -157,7 +158,13 @@ function SSIDSignalWaterfallChart(props) {
           data={formatData(waterfall)}
           layers={formatTracks(waterfall, waterfall.tracks)} />
 
-        <TrackDetectorConfigModal config={waterfall.detector_configuration} />
+        <TrackDetectorConfigModal
+            bssid={bssid}
+            ssid={ssid}
+            frequency={frequency}
+            tapUUID={selectedTaps[0]}
+            config={waterfall.detector_configuration}
+            setRevision={setRevision} />
 
         <button className="btn btn-sm btn-outline-secondary"
                 data-bs-toggle="modal"

--- a/web-interface/src/components/dot11/bssids/ssids/SSIDSignalWaterfallChart.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/SSIDSignalWaterfallChart.jsx
@@ -5,6 +5,7 @@ import Dot11Service from "../../../../services/Dot11Service";
 import HeatmapWaterfallChart from "../../../charts/HeatmapWaterfallChart";
 import SignalLegendHelper from "../../../charts/SignalLegendHelper";
 import {singleTapSelected} from "../../../../util/Tools";
+import TrackDetectorConfigModal from "./TrackDetectorConfigModal";
 
 const dot11Service = new Dot11Service();
 
@@ -145,14 +146,26 @@ function SSIDSignalWaterfallChart(props) {
     return <div style={{height: HEIGHT}}><LoadingSpinner /></div>
   }
 
-  return <HeatmapWaterfallChart
-      height={HEIGHT}
-      xaxistitle="Signal Strength (dBm)"
-      yaxistitle="Time"
-      hovertemplate="Signal Strength: %{x} dBm, %{z} frames at %{y}<extra></extra>"
-      annotations={SignalLegendHelper.DEFAULT}
-      data={formatData(waterfall)}
-      layers={formatTracks(waterfall, waterfall.tracks)} />
+  return (
+      <React.Fragment>
+        <HeatmapWaterfallChart
+          height={HEIGHT}
+          xaxistitle="Signal Strength (dBm)"
+          yaxistitle="Time"
+          hovertemplate="Signal Strength: %{x} dBm, %{z} frames at %{y}<extra></extra>"
+          annotations={SignalLegendHelper.DEFAULT}
+          data={formatData(waterfall)}
+          layers={formatTracks(waterfall, waterfall.tracks)} />
+
+        <TrackDetectorConfigModal config={waterfall.detector_configuration} />
+
+        <button className="btn btn-sm btn-outline-secondary"
+                data-bs-toggle="modal"
+                data-bs-target="#track-detector-config">
+          Configure Track Detector
+        </button>
+      </React.Fragment>
+  )
 
 }
 

--- a/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
@@ -1,6 +1,12 @@
-import React from "react";
+import React, {useState} from "react";
 
 function TrackDetectorConfigModal(props) {
+
+  const config = props.config;
+
+  const [frameThreshold, setFrameThreshold] = useState(config.frame_threshold);
+  const [gapThreshold, setGapThreshold] = useState(config.gap_threshold);
+  const [centerlineJitter, setCenterlineJitter] = useState(config.signal_centerline_jitter);
 
   return (
       <div className="modal fade"
@@ -25,7 +31,41 @@ function TrackDetectorConfigModal(props) {
                 <a href="https://go.nzyme.org/wifi-network-monitoring-signal-tracks" target="_blank">documentation</a>.
               </p>
 
-              
+              <div className="mb-3">
+                <label htmlFor="wf_config_frame_threshold" className="form-label">Frame Threshold</label>
+                <input type="text"
+                       className="form-control"
+                       id="wf_config_frame_threshold"
+                       value={frameThreshold} />
+                <div id="wf_config_frame_threshold_help" className="form-text">
+                  Minimum number of minutes with successively recorded frames required to start a new track.{' '}
+                  <strong>Default:</strong> {config.frame_threshold_default}
+                </div>
+              </div>
+              <div className="mb-3">
+                <label htmlFor="wf_config_gap_threshold" className="form-label">Gap Threshold</label>
+                <input type="text"
+                       className="form-control"
+                       id="wf_config_gap_threshold"
+                       value={gapThreshold} />
+                <div id="wf_config_gap_threshold_help" className="form-text">
+                  Maximum number of minutes with no recorded frames allowed before a track ends.{' '}
+                  <strong>Default:</strong> {config.gap_threshold_default}
+                </div>
+              </div>
+              <div className="mb-3">
+                <label htmlFor="wf_config_jitter_threshold" className="form-label">Signal Centerline Jitter</label>
+                <input type="text"
+                       className="form-control"
+                       id="wf_config_jitter_threshold"
+                       value={centerlineJitter}/>
+                <div id="wf_config_jitter_threshold_help" className="form-text">
+                  Maximum dBm of strength a signal is allowed to deviate from the track centerline. Think of this like
+                  the <i>width</i> of the track. Signals outside of the allowed jitter range will not break a track,
+                  but also not taken into account for track calculation.{' '}
+                  <strong>Default:</strong> {config.signal_centerline_jitter_default}
+                </div>
+              </div>
             </div>
             <div className="modal-footer">
               <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
@@ -1,11 +1,14 @@
-import React, {useState} from "react";
+import React, {useContext, useState} from "react";
 import Dot11Service from "../../../../services/Dot11Service";
 import {notify} from "react-notify-toast";
 import TrackDetectorConfigModalButton from "./TrackDetectorConfigModalButton";
+import {UserContext} from "../../../../App";
 
 const dot11Service = new Dot11Service();
 
 function TrackDetectorConfigModal(props) {
+
+  const user = useContext(UserContext);
 
   const bssid = props.bssid;
   const ssid = props.ssid;
@@ -69,6 +72,11 @@ function TrackDetectorConfigModal(props) {
                 about signal track configurations in the{' '}
                 <a href="https://go.nzyme.org/wifi-network-monitoring-signal-tracks" target="_blank">documentation</a>.
               </p>
+
+              {user.is_superadmin ?
+                  <div className="alert alert-warning">You are logged in as super administrator and changes you are
+                    making to this track detector configuration will be saved for the organization the currently selected
+                    tap belongs to.</div> : null }
 
               <div className="mb-3">
                 <label htmlFor="wf_config_frame_threshold" className="form-label">Frame Threshold</label>

--- a/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+function TrackDetectorConfigModal(props) {
+
+  return (
+      <div className="modal fade"
+           id="track-detector-config"
+           tabIndex="-1">
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h1 className="modal-title fs-5">Track Detector Configuration</h1>
+              <button type="button" className="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div className="modal-body">
+              <p>
+                The default track detector config is not always able to reliably detect signal tracks in all
+                environments. You can change the detector configuration for this specific BSSID, SSID and channel
+                combination.
+              </p>
+
+              <p>
+                Note that custom configurations are applied for all tenants of your organization. You can learn more
+                about signal track configurations in the{' '}
+                <a href="https://go.nzyme.org/wifi-network-monitoring-signal-tracks" target="_blank">documentation</a>.
+              </p>
+
+              
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+              <button type="button" className="btn btn-primary">Save changes</button>
+            </div>
+          </div>
+        </div>
+      </div>
+  )
+
+}
+
+export default TrackDetectorConfigModal;

--- a/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModal.jsx
@@ -1,12 +1,51 @@
 import React, {useState} from "react";
+import Dot11Service from "../../../../services/Dot11Service";
+import {notify} from "react-notify-toast";
+import TrackDetectorConfigModalButton from "./TrackDetectorConfigModalButton";
+
+const dot11Service = new Dot11Service();
 
 function TrackDetectorConfigModal(props) {
 
+  const bssid = props.bssid;
+  const ssid = props.ssid;
+  const frequency = props.frequency;
+  const tapUUID = props.tapUUID;
   const config = props.config;
+
+  const setRevision = props.setRevision;
+
+  const [formSubmitted, setFormSubmitted] = useState(false);
 
   const [frameThreshold, setFrameThreshold] = useState(config.frame_threshold);
   const [gapThreshold, setGapThreshold] = useState(config.gap_threshold);
   const [centerlineJitter, setCenterlineJitter] = useState(config.signal_centerline_jitter);
+
+  const updateConfig = (e) => {
+    e.preventDefault();
+
+    if (!confirm("Really update track detector configuration?")) {
+      return;
+    }
+
+    dot11Service.updateTrackDetectorConfig(
+        bssid, ssid, frequency, tapUUID, frameThreshold, gapThreshold, centerlineJitter, () => {
+          notify.show("Track detector configuration updated.", "success");
+          setFormSubmitted(true);
+        }
+    );
+  }
+
+  const onSuccessModalClose = (e) => {
+    e.preventDefault();
+    setRevision(prevRev => prevRev + 1);
+  }
+
+  const formReady = () => {
+    return parseInt(frameThreshold, 10) > 0
+        && parseInt(gapThreshold, 10) > 0
+        && parseInt(centerlineJitter, 10) > 0;
+  }
 
   return (
       <div className="modal fade"
@@ -36,6 +75,7 @@ function TrackDetectorConfigModal(props) {
                 <input type="text"
                        className="form-control"
                        id="wf_config_frame_threshold"
+                       onChange={(e) => setFrameThreshold(e.target.value)}
                        value={frameThreshold} />
                 <div id="wf_config_frame_threshold_help" className="form-text">
                   Minimum number of minutes with successively recorded frames required to start a new track.{' '}
@@ -47,6 +87,7 @@ function TrackDetectorConfigModal(props) {
                 <input type="text"
                        className="form-control"
                        id="wf_config_gap_threshold"
+                       onChange={(e) => setGapThreshold(e.target.value)}
                        value={gapThreshold} />
                 <div id="wf_config_gap_threshold_help" className="form-text">
                   Maximum number of minutes with no recorded frames allowed before a track ends.{' '}
@@ -58,6 +99,7 @@ function TrackDetectorConfigModal(props) {
                 <input type="text"
                        className="form-control"
                        id="wf_config_jitter_threshold"
+                       onChange={(e) => setCenterlineJitter(e.target.value)}
                        value={centerlineJitter}/>
                 <div id="wf_config_jitter_threshold_help" className="form-text">
                   Maximum dBm of strength a signal is allowed to deviate from the track centerline. Think of this like
@@ -68,8 +110,11 @@ function TrackDetectorConfigModal(props) {
               </div>
             </div>
             <div className="modal-footer">
-              <button type="button" className="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-              <button type="button" className="btn btn-primary">Save changes</button>
+              <TrackDetectorConfigModalButton formSubmitted={formSubmitted}
+                                              onSuccessModalClose={onSuccessModalClose}
+                                              onSubmit={updateConfig}
+                                              disabled={!formReady()} />
+
             </div>
           </div>
         </div>

--- a/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModalButton.jsx
+++ b/web-interface/src/components/dot11/bssids/ssids/TrackDetectorConfigModalButton.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+function TrackDetectorConfigModalButton(props) {
+
+  const formSubmitted = props.formSubmitted;
+  const onSuccessModalClose = props.onSuccessModalClose;
+  const onSubmit = props.onSubmit;
+  const disabled = props.disabled;
+
+  if (formSubmitted) {
+    return (
+        <button type="button" className="btn btn-success" data-bs-dismiss="modal" onClick={onSuccessModalClose}>
+          <i className="fa-regular fa-thumbs-up"></i>&nbsp;
+          <span>Configuration Saved &#8211; Close Dialog</span>
+        </button>
+    )
+  } else {
+    return (
+        <button type="button" className="btn btn-primary" onClick={onSubmit} disabled={disabled}>
+          Save changes
+        </button>
+    )
+  }
+
+}
+
+export default TrackDetectorConfigModalButton;

--- a/web-interface/src/components/misc/WithPermission.jsx
+++ b/web-interface/src/components/misc/WithPermission.jsx
@@ -1,4 +1,4 @@
-import React, {useContext} from "react";
+import {useContext} from "react";
 import {UserContext} from "../../App";
 import {userHasPermission} from "../../util/Tools";
 

--- a/web-interface/src/services/Dot11Service.js
+++ b/web-interface/src/services/Dot11Service.js
@@ -176,6 +176,12 @@ class Dot11Service {
     })
   }
 
+  updateTrackDetectorConfig(bssid, ssid, frequency, tapUUID, frameThreshold, gapThreshold, signalCenterlineJitter, successCallback) {
+    RESTClient.put("/dot11/networks/bssids/show/" + bssid + "/ssids/show/" + ssid + "/frequencies/show/" + frequency + "/signal/trackdetector/configuration",
+        {tap_id: tapUUID, frame_threshold: frameThreshold, gap_threshold: gapThreshold, signal_centerline_jitter: signalCenterlineJitter},
+        successCallback);
+  }
+
 }
 
 export default Dot11Service


### PR DESCRIPTION
Allows to configure custom signal track detector configurations for BSSID/SSID/Channel/Tap combinations. The default configuration is not always reliably identifying tracks.

The button to configure is directly under the signal waterfall chart on the BSSID/SSID/Channel details page.

Issue ticket: #903  

Before merge:

- [ ] Add documentation