### PR TITLE
Allow null successful/complete in Dhcpv4TransactionReport

### DIFF
--- a/src/main/java/app/nzyme/core/rest/resources/taps/reports/tables/dhcp/Dhcpv4TransactionReport.java
+++ b/src/main/java/app/nzyme/core/rest/resources/taps/reports/tables/dhcp/Dhcpv4TransactionReport.java
@@ -35,7 +35,9 @@ public abstract class Dhcpv4TransactionReport {
     public abstract DateTime firstPacket();
     public abstract DateTime latestPacket();
     public abstract Set<String> notes();
+    @Nullable
     public abstract Boolean successful();
+    @Nullable
     public abstract Boolean complete();
 
     @JsonCreator


### PR DESCRIPTION
## Problem

On a busy span-port ethernet tap, every DHCP transactions report is rejected by the leader with HTTP 400, and the `tap_error` health indicator goes red. Leader log:

```
ValueInstantiationException: Cannot construct instance of
`app.nzyme.core.rest.resources.taps.reports.tables.dhcp.Dhcpv4TransactionReport`,
problem: Null successful
 (through reference chain: DhcpTransactionsReport["four"]->ArrayList[0])
```

## Root cause

The tap ships every transaction in its in-memory table on each report cycle, including in-flight ones — clean-up of completed/expired entries happens *after* serialization (`tap/src/state/tables/dhcp_table.rs:204-236`). For mid-handshake transactions, `successful: Option<bool>` is `None` and serde emits `"successful": null` (no `#[serde(skip_serializing_if = ...)]` on the field). On a busy interface, every batch contains at least one such entry.

AutoValue treats `Boolean`-typed accessors as required-non-null unless they carry `@Nullable`. Boxing alone — done in 9c40ad96 ("Fix NULLABLE primitives in DHCP report") and 62f71d7f ("Timelines work #1431") — doesn't suppress the generated `requireNonNull` check; only the `@Nullable` annotation does.

The error string `"Null successful"` matches AutoValue's `Objects.requireNonNull(this.successful, "Null successful")` format exactly.

## Fix

Add `@Nullable` to `successful()` and `complete()`. This matches the six other nullable fields in the same DTO (`serverMac`, `requestedIpAddress`, `options`, `additionalOptions`, `vendorClass`, `timestamps`) and finishes the intent of the two prior commits that boxed these fields.

## Verification

Deployed the patched jar against a `2.0.0-alpha.18-SNAPSHOT` leader (4 taps, one of them a busy ethernet span-port). Result:

- The per-cycle `dhcp/transactions` HTTP 400 stream stops immediately after restart
- The `Null successful` `ValueInstantiationException` entries stop appearing in `nzyme.log`
- `tap_error` health indicator transitions `RED → GREEN` after one full metrics reporting cycle (≈5 min)